### PR TITLE
Remove irrelevant `orchestra/database` requirement since Laravel 5.8 support `--realpath` migration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,5 +98,8 @@ jobs:
           composer require "doctrine/dbal:${{ matrix.dbal }}" --dev --no-interaction --no-update
           composer install --prefer-dist --no-interaction --no-suggest
 
+      - name: Installed dependencies
+        run: composer show -D
+
       - name: Run tests
         run: vendor/bin/phpunit --exclude-group skipped

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,22 +19,16 @@ jobs:
         include:
           - laravel: 10.*
             testbench: 8.*
-            database: 8.*
           - laravel: 9.*
             testbench: 7.*
-            database: 7.*
           - laravel: 8.*
             testbench: 6.*
-            database: 6.*
           - laravel: 7.*
             testbench: 5.*
-            database: 5.*
           - laravel: 6.*
             testbench: 4.*
-            database: 4.*
           - laravel: 5.8.*
             testbench: 3.8.*
-            database: 3.8.*
         exclude:
           - laravel: 5.8.*
             php: '8.0'
@@ -94,7 +88,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "orchestra/database:${{ matrix.database }}" --no-interaction --no-update
+          composer require "illuminate/contracts:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer install --prefer-dist --no-interaction --no-suggest
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,16 +19,22 @@ jobs:
         include:
           - laravel: 10.*
             testbench: 8.*
+            dbal: 3.*
           - laravel: 9.*
             testbench: 7.*
+            dbal: 3.*
           - laravel: 8.*
             testbench: 6.*
+            dbal: 3.*
           - laravel: 7.*
             testbench: 5.*
+            dbal: 2.*
           - laravel: 6.*
             testbench: 4.*
+            dbal: 2.*
           - laravel: 5.8.*
             testbench: 3.8.*
+            dbal: 2.*
         exclude:
           - laravel: 5.8.*
             php: '8.0'
@@ -89,6 +95,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "illuminate/contracts:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "doctrine/dbal:${{ matrix.dbal }}" --dev --no-interaction --no-update
           composer install --prefer-dist --no-interaction --no-suggest
 
       - name: Run tests

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.9",
+        "doctrine/dbal": "^2.9|^3.1.4",
         "orchestra/testbench": "3.8.* || 3.9.* || ^4.0 || ^6.0 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.9",
-        "orchestra/database": "3.8.* || 3.9.* || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "orchestra/testbench": "3.8.* || 3.9.* || ^4.0 || ^6.0 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.9|^3.1.4",
+        "doctrine/dbal": "^2.9 || ^3.1.4",
         "orchestra/testbench": "3.8.* || 3.9.* || ^4.0 || ^6.0 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9.0"
     },


### PR DESCRIPTION
~~There's still an issue with DBAL for Laravel 10 but shouldn't block this PR.~~